### PR TITLE
check for time between ticks to know whether to toggle

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -19,7 +19,7 @@ function main() {
 registerPlugin({
   name: "OpenRCT2-AutomaticallyPause",
   version: "1.1",
-  authors: ["Ken"],
+  authors: ["Ken", "ltsSmitty"],
   type: "remote",
   licence: "Unlicense",
   targetApiVersion: 7,

--- a/plugin.js
+++ b/plugin.js
@@ -1,17 +1,27 @@
 function main() {
-    try {
-		context.executeAction("pausetoggle", {});
-	} catch (error) {
-		console.log(error);
-	}
+  var pluginStartTime = new Date().getTime();
+  var tickDispose = context.subscribe("interval.tick", function () {
+    var firstTickTime = new Date().getTime();
+    var timeBewteenTicks = firstTickTime - pluginStartTime;
+    if (timeBewteenTicks >= 500) {
+      console.log(
+        "gamefile was already paused on load, so no need to toggle; disposing of tick listener."
+      );
+      tickDispose.dispose();
+    } else {
+      console.log("not paused, so activating toggle."),
+        context.executeAction("pausetoggle", {}),
+        tickDispose.dispose();
+    }
+  });
 }
 
 registerPlugin({
-    name: 'OpenRCT2-AutomaticallyPause',
-    version: '1.1',
-    authors: ['Ken'],
-    type: 'remote',
-    licence: 'Unlicense',
-    targetApiVersion: 7,
-    main: main
+  name: "OpenRCT2-AutomaticallyPause",
+  version: "1.1",
+  authors: ["Ken"],
+  type: "remote",
+  licence: "Unlicense",
+  targetApiVersion: 7,
+  main: main,
 });


### PR DESCRIPTION
Since there's no way to know the status of the toggle, this PR attempts to address that by watching for the first tick to occur.

Game ticks only happen when the game is unpaused. So if the first tick doesn't occur for at least 500ms after plugin start (an arbitrary time that seems more than sufficient for catching the time of 1 game tick), then the park must have started paused, and there's no need to toggle pause on.

Otherwise, pause the game.